### PR TITLE
Added manual IP/Port updates

### DIFF
--- a/apps/jason0x43-wemo_connect.groovy
+++ b/apps/jason0x43-wemo_connect.groovy
@@ -37,6 +37,8 @@ preferences {
     page(name: 'mainPage')
 }
 
+import hubitat.helper.HexUtils
+
 def mainPage() {
     // Reset the refresh state if the last refresh was more than 60 seconds ago
     if (!state.refreshCount || !state.lastRefresh || (now() - state.lastRefresh) > 60000) {
@@ -716,4 +718,47 @@ private updateChildAddress(child, ip, port) {
     }
 
     childSubscribe(child)
+}
+
+def childUpdatePort(child, port) {
+    if (port < 1 || port > 65535 ) {
+        debugLog("Invalid TCP port specified - ${port}")
+        -1
+    } else {
+        def hPort = HexUtils.integerToHexString(port)
+        def existingPort = child.getDataValue('port')
+        
+        if (port && port != h2i(existingPort)) {
+            debugLog("childUpdate: ${child} - Updating port from ${Integer.parseInt(existingPort, 16)} to ${port}")
+            child.updateDataValue('port', hPort)
+        }
+    }
+}
+
+def childUpdateIP(child, ip) {
+    
+    String[] splitIp = ip.split("\\.")
+    
+    if (splitIp.length !=4) {
+        debugLog("Invalid IP address specified - ${ip} (${splitIp.length} octets found)")
+        -1
+    } else {
+        def intArrIp = strArrToIntArr(splitIp)
+        def hexIp = HexUtils.intArrayToHexString(intArrIp)
+
+        def existingIp = child.getDataValue('ip')
+        
+        if (ip && ip != hexToIp(existingIp)) {
+            debugLog("childUpdate: ${child} - Updating IP from ${hexToIp(existingIp)} to ${ip}")
+            child.updateDataValue('ip', hexIp)
+        }
+    }
+}
+
+private strArrToIntArr(strArr) {
+    int[] intArr = new int[strArr.length];
+    for (int i = 0; i < strArr.length; i++) {
+        intArr[i]=Integer.parseInt(strArr[i], 10)
+    }
+    intArr
 }

--- a/drivers/jason0x43-wemo_dimmer.groovy
+++ b/drivers/jason0x43-wemo_dimmer.groovy
@@ -43,6 +43,13 @@ metadata {
         command 'subscribe'
         command 'unsubscribe'
         command 'resubscribe'
+        command 'updateAddress',            [
+              [name:"IP Address", type: "STRING", description: "New IP address", constraints: []]
+            ]
+        command 'updatePort', 
+            [
+              [name:"TCP Port", type: "NUMBER", description: "New TCP port", constraints: []]
+            ]
     }
 }
 
@@ -252,4 +259,12 @@ private debugLog(message) {
 
 private syncTime() {
     parent.childSyncTime(device)
+}
+
+def updatePort(port) {
+    parent.childUpdatePort(device, port)
+}
+
+def updateAddress(ip) {
+    parent.childUpdateIP(device, ip)
 }

--- a/drivers/jason0x43-wemo_insight_switch.groovy
+++ b/drivers/jason0x43-wemo_insight_switch.groovy
@@ -39,6 +39,13 @@ metadata {
         command 'subscribe'
         command 'unsubscribe'
         command 'resubscribe'
+        command 'updateAddress',            [
+              [name:"IP Address", type: "STRING", description: "New IP address", constraints: []]
+            ]
+        command 'updatePort', 
+            [
+              [name:"TCP Port", type: "NUMBER", description: "New TCP port", constraints: []]
+            ]
     }
 }
 
@@ -226,4 +233,12 @@ private debugLog(message) {
 
 private syncTime() {
     parent.childSyncTime(device)
+}
+
+def updatePort(port) {
+    parent.childUpdatePort(device, port)
+}
+
+def updateAddress(ip) {
+    parent.childUpdateIP(device, ip)
 }

--- a/drivers/jason0x43-wemo_switch.groovy
+++ b/drivers/jason0x43-wemo_switch.groovy
@@ -37,15 +37,13 @@ metadata {
         command 'subscribe'
         command 'unsubscribe'
         command 'resubscribe'
-        command 'updateAddress',
-            [
+        command 'updateAddress',            [
               [name:"IP Address", type: "STRING", description: "New IP address", constraints: []]
             ]
         command 'updatePort', 
             [
-              [name:"TCP Port", type: "STRING", description: "New TCP port", constraints: []]
+              [name:"TCP Port", type: "NUMBER", description: "New TCP port", constraints: []]
             ]
-    }
     }
 }
 
@@ -189,83 +187,10 @@ private syncTime() {
     parent.childSyncTime(device)
 }
 
-
 def updatePort(port) {
-    iPort=s2i(port)
-    if (iPort < 1 || iPort > 65535 ) {
-        infoLog("Invalid TCP port specified - ${port}")
-        -1
-    } else {
-        hPort=i2h(iPort)
-        def existingPort = device.getDataValue('port')
-
-        infoLog("Existing Port: ${h2i(existingPort)}")
-        
-        if (iPort && iPort != h2i(existingPort)) {
-            debugLog("Updating port from ${h2i(existingPort)} to ${port}")
-            device.updateDataValue('port', hPort)
-        }
-        
-    }
+    parent.childUpdatePort(device, port)
 }
 
 def updateAddress(ip) {
-    
-    String[] splitIp = ip.split("\\.")
-    
-    if (splitIp.length !=4) {
-        infoLog("Invalid IP address specified - ${ip} (${splitIp.length} octets found)")
-        -1
-    } else {
-        intArrIp=strArrToIntArr(splitIp)
-        hexIp=intArrToHex(intArrIp)
-
-        def existingIp = device.getDataValue('ip')
-
-        infoLog("Existing IP: ${hexToIp(existingIp)}")
-        
-        if (ip && ip != hexToIp(existingIp)) {
-            debugLog("Updating IP from ${hexToIp(existingIp)} to ${ip}")
-            device.updateDataValue('ip', hexIp)
-        }
-    }
+    parent.childUpdateIP(device, ip)
 }
-
-private strArrToIntArr(strArr) {
-    int[] intArr = new int[strArr.length];
-    for (int i = 0; i < strArr.length; i++) {
-        intArr[i]=s2i(strArr[i])
-    }
-    intArr
-}
-
-private h2i(hex) {
-    //Hex to Integer
-    Integer.parseInt(hex,16)
-}
-
-private s2i(strV) {
-    //String to Integer
-    Integer.parseInt(strV, 10)
-}
-
-private hexToIp(hex) {
-    //Hex IP String to dotted decimal IP string
-    [
-        h2i(hex[0..1]),
-        h2i(hex[2..3]),
-        h2i(hex[4..5]),
-        h2i(hex[6..7])
-    ].join('.')
-}
-
-private intArrToHex(arrAddress) {
-    //integer array (split IP address) to Hex string
-    hubitat.helper.HexUtils.intArrayToHexString(arrAddress)
-}
-
-private i2h(i) {
-    //usage:  integerToHexString(value, minByteCount)
-    hubitat.helper.HexUtils.integerToHexString(i, 1)
-}
-

--- a/drivers/jason0x43-wemo_switch.groovy
+++ b/drivers/jason0x43-wemo_switch.groovy
@@ -37,6 +37,15 @@ metadata {
         command 'subscribe'
         command 'unsubscribe'
         command 'resubscribe'
+        command 'updateAddress',
+            [
+              [name:"IP Address", type: "STRING", description: "New IP address", constraints: []]
+            ]
+        command 'updatePort', 
+            [
+              [name:"TCP Port", type: "STRING", description: "New TCP port", constraints: []]
+            ]
+    }
     }
 }
 
@@ -179,3 +188,84 @@ private debugLog(message) {
 private syncTime() {
     parent.childSyncTime(device)
 }
+
+
+def updatePort(port) {
+    iPort=s2i(port)
+    if (iPort < 1 || iPort > 65535 ) {
+        infoLog("Invalid TCP port specified - ${port}")
+        -1
+    } else {
+        hPort=i2h(iPort)
+        def existingPort = device.getDataValue('port')
+
+        infoLog("Existing Port: ${h2i(existingPort)}")
+        
+        if (iPort && iPort != h2i(existingPort)) {
+            debugLog("Updating port from ${h2i(existingPort)} to ${port}")
+            device.updateDataValue('port', hPort)
+        }
+        
+    }
+}
+
+def updateAddress(ip) {
+    
+    String[] splitIp = ip.split("\\.")
+    
+    if (splitIp.length !=4) {
+        infoLog("Invalid IP address specified - ${ip} (${splitIp.length} octets found)")
+        -1
+    } else {
+        intArrIp=strArrToIntArr(splitIp)
+        hexIp=intArrToHex(intArrIp)
+
+        def existingIp = device.getDataValue('ip')
+
+        infoLog("Existing IP: ${hexToIp(existingIp)}")
+        
+        if (ip && ip != hexToIp(existingIp)) {
+            debugLog("Updating IP from ${hexToIp(existingIp)} to ${ip}")
+            device.updateDataValue('ip', hexIp)
+        }
+    }
+}
+
+private strArrToIntArr(strArr) {
+    int[] intArr = new int[strArr.length];
+    for (int i = 0; i < strArr.length; i++) {
+        intArr[i]=s2i(strArr[i])
+    }
+    intArr
+}
+
+private h2i(hex) {
+    //Hex to Integer
+    Integer.parseInt(hex,16)
+}
+
+private s2i(strV) {
+    //String to Integer
+    Integer.parseInt(strV, 10)
+}
+
+private hexToIp(hex) {
+    //Hex IP String to dotted decimal IP string
+    [
+        h2i(hex[0..1]),
+        h2i(hex[2..3]),
+        h2i(hex[4..5]),
+        h2i(hex[6..7])
+    ].join('.')
+}
+
+private intArrToHex(arrAddress) {
+    //integer array (split IP address) to Hex string
+    hubitat.helper.HexUtils.intArrayToHexString(arrAddress)
+}
+
+private i2h(i) {
+    //usage:  integerToHexString(value, minByteCount)
+    hubitat.helper.HexUtils.integerToHexString(i, 1)
+}
+


### PR DESCRIPTION
Moved my wifi to a different subnet which prevented the SSDP broadcasts from coming through to update the device IPs. Added functions (with helper functions) to allow manual update of dotted decimal IP address (no hexIP input needed from the user) or decimal TCP Port (49153 is default).  Copied partial functions from Wemo Connect app for Hex <=> IP dotted decimal info the driver.

If this is only useful for me, that's fine, it doesn't need to be integrated into the main line of code.